### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "html"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # My Programs
 Here is where I access myprograms and files from out of home.
+
+[![Run on Repl.it](https://repl.it/badge/github/Wowwer-wowamazing0com1wow/JavaStuff)](https://repl.it/github/Wowwer-wowamazing0com1wow/JavaStuff)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@CollinL8153/JavaStuff).